### PR TITLE
Remove deprecated 'failure_message_for_should'

### DIFF
--- a/lib/contract_verifier/matchers/schema_matcher.rb
+++ b/lib/contract_verifier/matchers/schema_matcher.rb
@@ -11,7 +11,7 @@ RSpec::Matchers.define :verify_response do |consumer_schema, provider_schema, ht
     result = check_errors(diff)
     result.blank?
   end
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     error_message(provider_schema, consumer_schema, result)
   end
 end
@@ -27,7 +27,7 @@ RSpec::Matchers.define :verify_request do |consumer_schema, provider_schema, htt
     result.blank?
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     error_message(provider_schema, consumer_schema, result)
   end
 end

--- a/lib/contract_verifier/matchers/url_matcher.rb
+++ b/lib/contract_verifier/matchers/url_matcher.rb
@@ -8,7 +8,7 @@ module Url
       Url.match? schema_url, url
     end
 
-    failure_message_for_should do |url|
+    failure_message do |url|
       "expected url #{url} does not match schema url #{schema_url}. Update schema file in #{schema_file}"
     end
 


### PR DESCRIPTION
Removed the deprecated 'failure_message_for_should'.Replaced with 'failure_message' method instead
